### PR TITLE
FEAT(FTDA): Define addTodo endpoint in the api slice

### DIFF
--- a/modules/HomePage/components/TaskForm/TaskForm.tsx
+++ b/modules/HomePage/components/TaskForm/TaskForm.tsx
@@ -4,9 +4,9 @@ import { DateInput } from "@mantine/dates";
 import { Container, Select, TextInput, Button, Group } from "@mantine/core";
 import "@mantine/dates/styles.css";
 
+import { useAddTodoMutation } from "@/services/todoApi";
 import { Task } from "../../types/Task";
 import classes from "./TaskForm.module.css";
-import { useAddTodoMutation } from "@/services/todoApi";
 
 interface TaskFormProps {
   addTask: (task: Task) => void;
@@ -34,10 +34,10 @@ const TaskForm: React.FC<TaskFormProps> = ({
       return;
     }
 
-    const priorityMapping: { [key: number]: 'HIGH' | 'MEDIUM' | 'LOW' } = {
-      1: 'HIGH',
-      2: 'MEDIUM',
-      3: 'LOW',
+    const priorityMapping: { [key: number]: "HIGH" | "MEDIUM" | "LOW" } = {
+      1: "HIGH",
+      2: "MEDIUM",
+      3: "LOW",
     };
     const newTask: Task = {
       title,
@@ -45,12 +45,10 @@ const TaskForm: React.FC<TaskFormProps> = ({
       priority: priorityMapping[priority],
       dueDate: dueDate,
       completed: false,
- 
     };
     try {
-      console.log(newTask);
       const result = await addTodo(newTask).unwrap();
-      console.log(result);
+
       setTitle("");
       setDescription("");
       setPriority(2);

--- a/modules/HomePage/components/TaskForm/TaskForm.tsx
+++ b/modules/HomePage/components/TaskForm/TaskForm.tsx
@@ -6,6 +6,7 @@ import "@mantine/dates/styles.css";
 
 import { Task } from "../../types/Task";
 import classes from "./TaskForm.module.css";
+import { useAddTodoMutation } from "@/services/todoApi";
 
 interface TaskFormProps {
   addTask: (task: Task) => void;
@@ -15,7 +16,6 @@ interface TaskFormProps {
 }
 
 const TaskForm: React.FC<TaskFormProps> = ({
-  addTask,
   deleteCompletedTasks,
   setFilter,
   filter,
@@ -25,25 +25,39 @@ const TaskForm: React.FC<TaskFormProps> = ({
   const [priority, setPriority] = useState<number>(2);
   const [dueDate, setDueDate] = useState<Date | null>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const [addTodo] = useAddTodoMutation();
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title || !description || !priority || !dueDate) {
       alert("Please fill in all fields");
       return;
     }
+
+    const priorityMapping: { [key: number]: 'HIGH' | 'MEDIUM' | 'LOW' } = {
+      1: 'HIGH',
+      2: 'MEDIUM',
+      3: 'LOW',
+    };
     const newTask: Task = {
-      id: new Date().toISOString(),
       title,
       description,
-      priority,
-      dueDate,
+      priority: priorityMapping[priority],
+      dueDate: dueDate,
       completed: false,
+ 
     };
-    addTask(newTask);
-    setTitle("");
-    setDescription("");
-    setPriority(2);
-    setDueDate(null);
+    try {
+      console.log(newTask);
+      const result = await addTodo(newTask).unwrap();
+      console.log(result);
+      setTitle("");
+      setDescription("");
+      setPriority(2);
+      setDueDate(null);
+    } catch (error) {
+      console.error("Failed to add the todo:", error);
+    }
   };
 
   return (

--- a/modules/HomePage/components/TaskList/TaskList.tsx
+++ b/modules/HomePage/components/TaskList/TaskList.tsx
@@ -19,8 +19,6 @@ import { PRIORITY_OPTIONS } from "@/shared/constants/taskContstants";
 import { Task } from "../../types/Task";
 import classes from "./TaskList.module.css";
 
-
-
 interface TaskListProps {
   sortedTasks: Task[];
   deleteTask: (id: string) => void;
@@ -44,8 +42,8 @@ const TaskList: React.FC<TaskListProps> = ({
     title: string;
     description: string;
     dueDate: string;
-    priority: number;
-  }>({ title: "", description: "", dueDate: "", priority: 1 });
+    priority: "HIGH" | "MEDIUM" | "LOW";
+  }>({ title: "", description: "", dueDate: "", priority: "MEDIUM" });
 
   useEffect(() => {
     if (editingTaskId) {
@@ -94,14 +92,19 @@ const TaskList: React.FC<TaskListProps> = ({
       priority: editFormState.priority,
     };
     saveTask(updatedTask);
-    setEditFormState({ title: "", description: "", dueDate: "", priority: 1 });
+    setEditFormState({
+      title: "",
+      description: "",
+      dueDate: "",
+      priority: "MEDIUM",
+    });
   };
   const { data: todos, isLoading } = useGetTodosQuery();
 
   if (isLoading) {
     return <Loader size="xl" />;
   }
-  
+
   return (
     <div>
       <Modal opened={opened} onClose={close} title="Are you sure?" centered>
@@ -140,7 +143,7 @@ const TaskList: React.FC<TaskListProps> = ({
                   Priority: {task.priority}
                 </Text>
                 <Text className={classes.taskDueDate}>
-                  Due Date: {new Date(task.dueDate).toDateString()}
+                  Due Date: {new Date(task.dueDate ?? "").toDateString()}
                 </Text>
               </Group>
             </div>
@@ -167,12 +170,12 @@ const TaskList: React.FC<TaskListProps> = ({
               />
               <Select
                 name="priority"
-                value={editFormState.priority.toString()}
+                value={editFormState.priority}
                 onChange={(value) => {
                   if (value) {
                     setEditFormState((prev) => ({
                       ...prev,
-                      priority: parseInt(value, 10),
+                      priority: value as "HIGH" | "MEDIUM" | "LOW",
                     }));
                   }
                 }}
@@ -185,21 +188,21 @@ const TaskList: React.FC<TaskListProps> = ({
               <Button
                 color="red"
                 style={{ display: task.completed ? "none" : "inline-block" }}
-                onClick={() => openModalHandler(task.id)}
+                onClick={() => openModalHandler(task.id ?? "")}
               >
                 Delete
               </Button>
               <Button
                 color="green"
                 style={{ display: task.completed ? "none" : "inline-block" }}
-                onClick={() => isCompleteHandler(task.id)}
+                onClick={() => isCompleteHandler(task.id ?? "")}
               >
                 Complete
               </Button>
               <Button
                 color="orange"
                 style={{ display: task.completed ? "none" : "inline-block" }}
-                onClick={() => startEditingTask(task.id)}
+                onClick={() => startEditingTask(task.id ?? "")}
               >
                 Edit
               </Button>

--- a/modules/HomePage/components/TaskList/TaskList.tsx
+++ b/modules/HomePage/components/TaskList/TaskList.tsx
@@ -143,7 +143,7 @@ const TaskList: React.FC<TaskListProps> = ({
                   Priority: {task.priority}
                 </Text>
                 <Text className={classes.taskDueDate}>
-                  Due Date: {new Date(task.dueDate ?? "").toDateString()}
+                  Due Date: {task.dueDate ? new Date(task.dueDate).toDateString() : "No due date"}
                 </Text>
               </Group>
             </div>

--- a/modules/HomePage/types/Task.ts
+++ b/modules/HomePage/types/Task.ts
@@ -1,8 +1,8 @@
 export interface Task {
-    id: string 
-    title: string 
-    description: string 
-    priority: number
-    dueDate: Date 
-    completed: boolean; 
+  id?: string;
+  title: string;
+  description: string;
+  priority?: "HIGH" | "MEDIUM" | "LOW";
+  dueDate?: Date;
+  completed: boolean;
 }

--- a/services/todoApi.ts
+++ b/services/todoApi.ts
@@ -5,11 +5,21 @@ import { Task } from "@/modules/HomePage/types/Task";
 export const todoApi = createApi({
   reducerPath: "todoApi",
   baseQuery: fetchBaseQuery({ baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL }),
+  tagTypes: ['Todo'],
   endpoints: (builder) => ({
     getTodos: builder.query<Task[], void>({
       query: () => "/todos",
+      providesTags: ["Todo"],
+    }),
+    addTodo: builder.mutation({
+      query: (newTodo) => ({
+        url: "/todos",
+        method: "POST",
+        body: newTodo,
+      }),
+      invalidatesTags: ["Todo"],
     }),
   }),
 });
 
-export const { useGetTodosQuery } = todoApi;
+export const { useGetTodosQuery, useAddTodoMutation } = todoApi;


### PR DESCRIPTION
**DESCRIPTION OF CHANGES**

- Define addTodo endpoint in the API slice 
- Provide tag in the fetch query 
- Enabled automatic re-fetching of the TODO list after adding new items by invalidating the Todo cache tag

https://github.com/user-attachments/assets/9c4018b6-d60b-4bd0-bc12-80b806aea8db

