### PR TITLE
FEAT(FTDA): Define deleteTodo endpoint in api slice

### DIFF
--- a/services/todoApi.ts
+++ b/services/todoApi.ts
@@ -27,6 +27,14 @@ export const todoApi = createApi({
       }),
       invalidatesTags: ["Todos"],
     }),
+    updateTodo: builder.mutation({
+      query: ({ id, ...updatedTodo }) => ({
+        url: `/todos/${id}`,
+        method: "PUT",
+        body: updatedTodo,
+      }),
+      invalidatesTags: ["Todo"],
+    }),
   }),
 });
 

--- a/services/todoApi.ts
+++ b/services/todoApi.ts
@@ -27,14 +27,6 @@ export const todoApi = createApi({
       }),
       invalidatesTags: ["Todos"],
     }),
-    updateTodo: builder.mutation({
-      query: ({ id, ...updatedTodo }) => ({
-        url: `/todos/${id}`,
-        method: "PUT",
-        body: updatedTodo,
-      }),
-      invalidatesTags: ["Todo"],
-    }),
   }),
 });
 

--- a/services/todoApi.ts
+++ b/services/todoApi.ts
@@ -27,7 +27,14 @@ export const todoApi = createApi({
       }),
       invalidatesTags: ["Todos"],
     }),
+    deleteTodo: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `/todos/${id}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Todos"],
+    }),
   }),
 });
 
-export const { useGetTodosQuery, useAddTodoMutation, useUpdateTodoMutation  } = todoApi;
+export const { useGetTodosQuery, useAddTodoMutation, useUpdateTodoMutation, useDeleteTodoMutation } = todoApi;


### PR DESCRIPTION


https://github.com/user-attachments/assets/6443732c-8b31-4258-b3bf-0ee58cf8ae65

**DESCRIPTION OF CHANGES**

- Define deleteTodo endpoint in the API slice
- Extract the deleteTodo function from the useDeleteTodoMutation() hook.
- Use deleteTodo function to send task id to be deleted to the BE