### PR TITLE
Define completeTodo endpoint in api slice

### DIFF
--- a/modules/HomePage/components/TaskForm/TaskForm.tsx
+++ b/modules/HomePage/components/TaskForm/TaskForm.tsx
@@ -45,7 +45,7 @@ const TaskForm: React.FC<TaskFormProps> = ({
       description,
       priority: priorityMapping[priority],
       dueDate: dueDate,
-      completed: false,
+      isCompleted: false,
  
     };
     try {

--- a/modules/HomePage/types/Task.ts
+++ b/modules/HomePage/types/Task.ts
@@ -4,5 +4,5 @@ export interface Task {
   description: string;
   priority?: "HIGH" | "MEDIUM" | "LOW";
   dueDate?: Date;
-  completed: boolean;
+  isCompleted: boolean;
 }

--- a/services/todoApi.ts
+++ b/services/todoApi.ts
@@ -34,7 +34,15 @@ export const todoApi = createApi({
       }),
       invalidatesTags: ["Todos"],
     }),
+
+    completeTodo: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `/todos/${id}/complete`,
+        method: "PATCH",
+      }),
+      invalidatesTags: ["Todos"],
+    }),
   }),
 });
 
-export const { useGetTodosQuery, useAddTodoMutation, useUpdateTodoMutation, useDeleteTodoMutation } = todoApi;
+export const { useGetTodosQuery, useAddTodoMutation, useUpdateTodoMutation, useDeleteTodoMutation, useCompleteTodoMutation } = todoApi;


### PR DESCRIPTION
**DESCRIPTION OF CHANGES**

- Define the completeTodo endpoint in the api slice
- Update Task interface's `complete` property to `isCompleted` to match the BE response 
- Use the generated hook from the api slice to handle marking a Task as completed 

https://github.com/user-attachments/assets/35a83213-0dc7-480b-9380-5879e01b93c0

