### PR TITLE
FEAT(FTDA): Implement deletion of all completed todo items

### DIFF
--- a/modules/HomePage/components/TaskForm/TaskForm.tsx
+++ b/modules/HomePage/components/TaskForm/TaskForm.tsx
@@ -4,15 +4,14 @@ import { DateInput } from "@mantine/dates";
 import { Container, Select, TextInput, Button, Group } from "@mantine/core";
 import "@mantine/dates/styles.css";
 import { notifications } from "@mantine/notifications";
-
-import { useAddTodoMutation } from "@/services/todoApi";
-import { Task } from "../../types/Task";
-import classes from "./TaskForm.module.css";
 import {
   useAddTodoMutation,
   useDeleteCompletedTodosMutation,
   useGetTodosQuery,
 } from "@/services/todoApi";
+
+import { Task } from "../../types/Task";
+import classes from "./TaskForm.module.css";
 
 interface TaskFormProps {
   addTask: (task: Task) => void;
@@ -35,7 +34,7 @@ const TaskForm: React.FC<TaskFormProps> = ({
   const [deleteCompletedTodos] = useDeleteCompletedTodosMutation();
   const { data: todos = [] } = useGetTodosQuery();
 
-  const hasCompletedTasks = todos.some(task => task.isCompleted);
+  const hasCompletedTasks = todos.some((task) => task.isCompleted);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -172,7 +171,7 @@ const TaskForm: React.FC<TaskFormProps> = ({
           <Button
             className={classes.formButton}
             onClick={handleDeleteCompletedTasks}
-            disabled={!hasCompletedTasks} 
+            disabled={!hasCompletedTasks}
           >
             Clear Completed
           </Button>

--- a/modules/HomePage/components/TaskForm/TaskForm.tsx
+++ b/modules/HomePage/components/TaskForm/TaskForm.tsx
@@ -3,11 +3,16 @@ import React, { useState } from "react";
 import { DateInput } from "@mantine/dates";
 import { Container, Select, TextInput, Button, Group } from "@mantine/core";
 import "@mantine/dates/styles.css";
+import { notifications } from "@mantine/notifications";
 
 import { useAddTodoMutation } from "@/services/todoApi";
 import { Task } from "../../types/Task";
 import classes from "./TaskForm.module.css";
-import { useAddTodoMutation } from "@/services/todoApi";
+import {
+  useAddTodoMutation,
+  useDeleteCompletedTodosMutation,
+  useGetTodosQuery,
+} from "@/services/todoApi";
 
 interface TaskFormProps {
   addTask: (task: Task) => void;
@@ -27,6 +32,10 @@ const TaskForm: React.FC<TaskFormProps> = ({
   const [dueDate, setDueDate] = useState<Date | null>(null);
 
   const [addTodo] = useAddTodoMutation();
+  const [deleteCompletedTodos] = useDeleteCompletedTodosMutation();
+  const { data: todos = [] } = useGetTodosQuery();
+
+  const hasCompletedTasks = todos.some(task => task.isCompleted);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -46,7 +55,6 @@ const TaskForm: React.FC<TaskFormProps> = ({
       priority: priorityMapping[priority],
       dueDate: dueDate,
       isCompleted: false,
- 
     };
     try {
       const result = await addTodo(newTask).unwrap();
@@ -57,6 +65,24 @@ const TaskForm: React.FC<TaskFormProps> = ({
       setDueDate(null);
     } catch (error) {
       console.error("Failed to add the todo:", error);
+    }
+  };
+
+  const handleDeleteCompletedTasks = async () => {
+    try {
+      await deleteCompletedTodos().unwrap();
+      notifications.show({
+        title: "Cleared Completed Tasks",
+        message: "All completed tasks have been deleted.",
+        color: "red",
+      });
+    } catch (error) {
+      notifications.show({
+        title: "Error",
+        message: "Failed to delete completed tasks.",
+        color: "red",
+      });
+      console.error("Failed to delete completed tasks:", error);
     }
   };
 
@@ -143,7 +169,11 @@ const TaskForm: React.FC<TaskFormProps> = ({
           <Button className={classes.formButton} type="submit">
             Add Task
           </Button>
-          <Button className={classes.formButton} onClick={deleteCompletedTasks}>
+          <Button
+            className={classes.formButton}
+            onClick={handleDeleteCompletedTasks}
+            disabled={!hasCompletedTasks} 
+          >
             Clear Completed
           </Button>
           <Select

--- a/services/todoApi.ts
+++ b/services/todoApi.ts
@@ -42,7 +42,15 @@ export const todoApi = createApi({
       }),
       invalidatesTags: ["Todos"],
     }),
+
+    deleteCompletedTodos: builder.mutation<void, void>({
+      query: () => ({
+        url: `/todos/completed`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Todos"], 
+    }),
   }),
 });
 
-export const { useGetTodosQuery, useAddTodoMutation, useUpdateTodoMutation, useDeleteTodoMutation, useCompleteTodoMutation } = todoApi;
+export const { useGetTodosQuery, useAddTodoMutation, useUpdateTodoMutation, useDeleteTodoMutation, useCompleteTodoMutation, useDeleteCompletedTodosMutation } = todoApi;


### PR DESCRIPTION
**DESCRIPTION OF CHANGES**

- Define the deleteCompletedTodos endpoint in the api slice
- Use the generated hook from the api slice to handle deletion of all completed todos
- Fetched tasks with useGetTodosQuery and used a state check to disable the button when no tasks are completed


https://github.com/user-attachments/assets/785f990d-d7e6-427f-b558-9e695c84ac86

